### PR TITLE
Specify platform in Dockerfile to avoid conflicts with local docker-compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # DESCRIPTION: Amazon MWAA Local Dev Environment
 # BUILD: docker build --rm -t amazon/mwaa-local .
 
-FROM amazonlinux
+FROM --platform=linux/amd64 amazonlinux
 LABEL maintainer="amazon"
 
 # Airflow


### PR DESCRIPTION
Running `mwaa-local-env build-image` followed by `mwaa-local-env start` currently fails on ARM-based systems, because the MWAA image is built for the default platform and the docker-compose file used by `start` is looking for an AMD64 image.

An alternative approach would be to remove the platform specification in `docker-compose-local.yml`.